### PR TITLE
3010merge3

### DIFF
--- a/modules/packetizer/hevc.c
+++ b/modules/packetizer/hevc.c
@@ -51,12 +51,18 @@
 static int  Open (vlc_object_t *);
 static void Close(vlc_object_t *);
 
+#define INTRA_TEXT N_("Enable decoding of HEVC P/B-frame only streams")
+#define INTRA_LONGTEXT N_(\
+    "Some low latency HEVC video encoders don't produce iframes. " \
+    "Enable this if you have HEVC that will not decode")
+
 vlc_module_begin ()
     set_category(CAT_SOUT)
     set_subcategory(SUBCAT_SOUT_PACKETIZER)
     set_description(N_("HEVC/H.265 video packetizer"))
     set_capability("packetizer", 50)
     set_callbacks(Open, Close)
+    add_bool("accept-hevc-intra", true, INTRA_TEXT, INTRA_LONGTEXT, false)
 vlc_module_end ()
 
 
@@ -760,6 +766,9 @@ static block_t * ParseAUHead(decoder_t *p_dec, uint8_t i_nal_type, block_t *p_na
         case HEVC_NAL_SPS:
         case HEVC_NAL_PPS:
         {
+            if (!p_sys->b_init_sequence_complete) {
+                p_sys->b_init_sequence_complete = var_InheritBool(p_dec, "accept-hevc-intra");
+            }
             uint8_t i_id;
             const uint8_t *p_xps = p_nalb->p_buffer;
             size_t i_xps = p_nalb->i_buffer;

--- a/modules/packetizer/hevc.c
+++ b/modules/packetizer/hevc.c
@@ -51,18 +51,12 @@
 static int  Open (vlc_object_t *);
 static void Close(vlc_object_t *);
 
-#define INTRA_TEXT N_("Enable decoding of HEVC P/B-frame only streams")
-#define INTRA_LONGTEXT N_(\
-    "Some low latency HEVC video encoders don't produce iframes. " \
-    "Enable this if you have HEVC that will not decode")
-
 vlc_module_begin ()
     set_category(CAT_SOUT)
     set_subcategory(SUBCAT_SOUT_PACKETIZER)
     set_description(N_("HEVC/H.265 video packetizer"))
     set_capability("packetizer", 50)
     set_callbacks(Open, Close)
-    add_bool("accept-hevc-intra", true, INTRA_TEXT, INTRA_LONGTEXT, false)
 vlc_module_end ()
 
 
@@ -651,9 +645,6 @@ static void ParseStoredSEI( decoder_t *p_dec )
         {
             HxxxParse_AnnexB_SEI( p_nal->p_buffer, p_nal->i_buffer,
                                   2 /* nal header */, ParseSEICallback, p_dec );
-            if (!p_sys->b_init_sequence_complete) {
-                p_sys->b_init_sequence_complete = var_InheritBool(p_dec, "accept-hevc-intra");
-            }
         }
     }
 }


### PR DESCRIPTION
LTN Encoder streams (progressive) don't have any SEI, so the prior workaround I though safe turned out not to be. I've moved the check out of the SEI specific code into the SPS specific code. Testing with the ateme hevc stream (interlaced) is fine. Testing with the LTN encoder progressive is also fine (as it interlaced).