### PR TITLE
Add low latency mode

### DIFF
--- a/extras/package/macosx/build.sh
+++ b/extras/package/macosx/build.sh
@@ -218,6 +218,7 @@ export OBJCFLAGS="-Werror=partial-availability"
 export EXTRA_CFLAGS="-isysroot $SDKROOT -mmacosx-version-min=$MINIMAL_OSX_VERSION -DMACOSX_DEPLOYMENT_TARGET=$MINIMAL_OSX_VERSION"
 export EXTRA_LDFLAGS="-Wl,-syslibroot,$SDKROOT -mmacosx-version-min=$MINIMAL_OSX_VERSION -isysroot $SDKROOT -DMACOSX_DEPLOYMENT_TARGET=$MINIMAL_OSX_VERSION"
 export XCODE_FLAGS="MACOSX_DEPLOYMENT_TARGET=$MINIMAL_OSX_VERSION -sdk macosx$OSX_VERSION WARNING_CFLAGS=-Werror=partial-availability"
+export XCODE_FLAGS="MACOSX_DEPLOYMENT_TARGET=$MINIMAL_OSX_VERSION -sdk $SDKROOT WARNING_CFLAGS=-Werror=partial-availability"
 
 info "Building contribs"
 spushd "${vlcroot}/contrib"

--- a/extras/package/macosx/dmg/dmg_settings.py
+++ b/extras/package/macosx/dmg/dmg_settings.py
@@ -27,7 +27,7 @@ appname = os.path.basename(application)
 format = defines.get('format', 'UDBZ')
 
 # Volume size (must be large enough for your files)
-size = defines.get('size', '150M')
+size = defines.get('size', '250M')
 
 # Files to include
 files = [ application ]

--- a/include/vlc_codec.h
+++ b/include/vlc_codec.h
@@ -70,6 +70,9 @@ struct decoder_t
     /* Tell the decoder if it is allowed to drop frames */
     bool                b_frame_drop_allowed;
 
+    /* Tell decoder to prioritize low-latency */
+    bool                b_low_latency;
+
 #   define VLCDEC_SUCCESS   VLC_SUCCESS
 #   define VLCDEC_ECRITICAL VLC_EGENERIC
 #   define VLCDEC_RELOAD    (-100)

--- a/modules/codec/avcodec/video.c
+++ b/modules/codec/avcodec/video.c
@@ -1098,30 +1098,6 @@ static picture_t *DecodeBlock( decoder_t *p_dec, block_t **pp_block, bool *error
 
         wait_mt( p_sys );
 
-        /*
-        static bool do_reset = true;
-        //msg_Err(p_dec, "blocks=%d", clock_count);
-        switch(frame->pict_type)
-        {
-            case AV_PICTURE_TYPE_I:
-                msg_Err(p_dec, "pict_type=I");
-                if (do_reset) {
-                    //input_clock_Reset(p_sys->);
-                    do_reset = false;
-                }
-                break;
-            case AV_PICTURE_TYPE_P:
-                msg_Err(p_dec, "pict_type=P");
-                break;
-            case AV_PICTURE_TYPE_S:
-                msg_Err(p_dec, "pict_type=S");
-                break;
-            case AV_PICTURE_TYPE_B:
-                msg_Err(p_dec, "pict_type=B");
-                break;
-        }
-        */
-
         if( eos_spotted )
             p_sys->b_first_frame = true;
 

--- a/modules/codec/avcodec/video.c
+++ b/modules/codec/avcodec/video.c
@@ -643,6 +643,12 @@ int InitVideoDec( vlc_object_t *obj )
     p_dec->pf_decode = DecodeVideo;
     p_dec->pf_flush  = Flush;
 
+    /* low latency mode */
+    if (var_InheritBool(p_dec, "low-latency") == true) {
+        //p_dec->b_frame_drop_allowed = false;
+        msg_Dbg( p_dec, "Low latency mode. Will not drop late frames." );
+    }
+
     /* XXX: Writing input format makes little sense. */
     if( p_context->profile != FF_PROFILE_UNKNOWN )
         p_dec->fmt_in.i_profile = p_context->profile;
@@ -1091,6 +1097,30 @@ static picture_t *DecodeBlock( decoder_t *p_dec, block_t **pp_block, bool *error
         bool not_received_frame = ret;
 
         wait_mt( p_sys );
+
+        /*
+        static bool do_reset = true;
+        //msg_Err(p_dec, "blocks=%d", clock_count);
+        switch(frame->pict_type)
+        {
+            case AV_PICTURE_TYPE_I:
+                msg_Err(p_dec, "pict_type=I");
+                if (do_reset) {
+                    //input_clock_Reset(p_sys->);
+                    do_reset = false;
+                }
+                break;
+            case AV_PICTURE_TYPE_P:
+                msg_Err(p_dec, "pict_type=P");
+                break;
+            case AV_PICTURE_TYPE_S:
+                msg_Err(p_dec, "pict_type=S");
+                break;
+            case AV_PICTURE_TYPE_B:
+                msg_Err(p_dec, "pict_type=B");
+                break;
+        }
+        */
 
         if( eos_spotted )
             p_sys->b_first_frame = true;

--- a/src/input/clock.c
+++ b/src/input/clock.c
@@ -623,8 +623,6 @@ static mtime_t ClockStreamToSystem( input_clock_t *cl, mtime_t i_stream )
     mtime_t i_time = (( i_stream - cl->ref.i_stream ) * cl->i_rate / INPUT_RATE_DEFAULT +
            cl->ref.i_system) - cl->i_latency_offset;
 
-    //printf("i_stream=%"PRId64", ref.i_stream=%"PRId64", ref.i_system=%"PRId64", i_latency_offset=%"PRId64"\n", i_stream, cl->ref.i_stream, cl->ref.i_system, cl->i_latency_offset);
-
     return i_time;
 }
 

--- a/src/input/clock.h
+++ b/src/input/clock.h
@@ -116,6 +116,8 @@ int input_clock_ConvertTS( vlc_object_t *, input_clock_t *, int *pi_rate,
  */
 int input_clock_GetRate( input_clock_t * );
 
+void input_clock_ReduceLatency(input_clock_t *cl, mtime_t stream_time);
+
 /**
  * This function returns current clock state or VLC_EGENERIC if there is not a
  * reference point.

--- a/src/input/decoder.c
+++ b/src/input/decoder.c
@@ -1096,7 +1096,6 @@ static int DecoderPlayVideo( decoder_t *p_dec, picture_t *p_picture,
     int64_t avdiff = (last_audio_timestamp - p_picture->date);
     int64_t combined_difference = (diff + avdiff);
     msg_Dbg( p_dec, "video d1=%"PRId64", d2=%"PRId64", now=%"PRId64" (diff=%"PRId64") (avdiff=%"PRId64") (combined=%"PRId64")", d1, d2, now, diff, avdiff, combined_difference);
-    //printf("latency %"PRId64" (%"PRId64") (%"PRId64")\n", diff, avdiff, combined_difference);
     
     if (p_dec->b_low_latency) 
     {
@@ -1111,11 +1110,6 @@ static int DecoderPlayVideo( decoder_t *p_dec, picture_t *p_picture,
                 msg_Dbg( p_dec, "clock too far behind live, in low-latency mode...correcting");
 
                 mtime_t adjustment = diff;
-                //if (diff < 0) {
-                //    adjustment = diff;
-                //    msg_Dbg( p_dec, "adjusting forward... %"PRId64"", adjustment);
-                //}
-                
                 input_clock_ReduceLatency(p_owner->p_clock, adjustment);
 
                 // recalculate presentation time for this frame

--- a/src/libvlc-module.c
+++ b/src/libvlc-module.c
@@ -470,6 +470,10 @@ static const char *const ppsz_pos_descriptions[] =
     "Enables framedropping on MPEG2 stream. Framedropping " \
     "occurs when your computer is not powerful enough" )
 
+#define LOW_LATENCY_TEXT N_("Low Latency Mode")
+#define LOW_LATENCY_LONGTEXT N_( \
+    "Prioritizes low latency playback over quality" )
+
 #define DROP_LATE_FRAMES_TEXT N_("Drop late frames")
 #define DROP_LATE_FRAMES_LONGTEXT N_( \
     "This drops frames that are late (arrive to the video output after " \
@@ -1570,6 +1574,8 @@ vlc_module_begin ()
     /* Used in vout_synchro */
     add_bool( "skip-frames", 1, SKIP_FRAMES_TEXT,
               SKIP_FRAMES_LONGTEXT, true )
+    add_bool( "low-latency", 0, LOW_LATENCY_TEXT,
+              LOW_LATENCY_LONGTEXT, true )
     add_bool( "quiet-synchro", 0, QUIET_SYNCHRO_TEXT,
               QUIET_SYNCHRO_LONGTEXT, true )
     add_bool( "keyboard-events", true, KEYBOARD_EVENTS_TEXT,

--- a/src/video_output/video_output.c
+++ b/src/video_output/video_output.c
@@ -887,7 +887,15 @@ static int ThreadDisplayPreparePicture(vout_thread_t *vout, bool reuse, bool fra
                         late_threshold = VOUT_DISPLAY_LATE_THRESHOLD;
                     const mtime_t predicted = mdate() + 0; /* TODO improve */
                     const mtime_t late = predicted - decoded->date;
+
+                    bool display_late = false;
                     if (late > late_threshold) {
+                        if (var_InheritBool(vout, "low-latency")) {
+                            display_late = true;
+                            msg_Warn(vout, "Picture late, but displaying anyway");
+                        }
+                    }
+                    if (late > late_threshold || display_late) {
                         msg_Warn(vout, "picture is too late to be displayed (missing %"PRId64" ms)", late/1000);
                         picture_Release(decoded);
                         vout_statistic_AddLost(&vout->p->statistic, 1);


### PR DESCRIPTION
This change adds a low latency mode to VLC. This mode is activated using the -low-latency command line parameter. 

Low latency mode works by adjusting the base reference clock timestamp when it detects any significant delays in the presentation of video frames. 

The default dmg image size has also been increased, since the default 150M size would always fail. 